### PR TITLE
Disable AVX512 on ImageMagick

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update &&  \
   # Install imagemagick with HEIF delegates
 RUN  t=$(mktemp) && \
         wget 'https://dist.1-2.dev/imei.sh' -qO "$t" && \
-        bash "$t" && \
+        bash "$t" --build-cflags "-mno-avx512f" --build-cxxflags "-mno-avx512f" && \
         rm "$t"
 RUN apt-get update &&  \
     apt-get install -y \


### PR DESCRIPTION
CI machines might have AVX512 CPU flag, which leads to compiled ImageMagick relying on it to be run within the docker container. This pose an incompatibility with older machines that don't have AVX512. 
